### PR TITLE
Does not work with Vagrant version >=1.6.0

### DIFF
--- a/lib/vagrant-autodns/command.rb
+++ b/lib/vagrant-autodns/command.rb
@@ -15,10 +15,10 @@ module VagrantAutoDNS
     end
 
     #Available subcommands
-    def initialize(argv, env)
-      super
+    def initialize(*args)
+      super(*args)
 
-      @main_args, @sub_command, @sub_args = split_main_and_subcommand(argv)
+      @main_args, @sub_command, @sub_args = split_main_and_subcommand(@argv)
 
       @subcommands = Vagrant::Registry.new
 
@@ -80,6 +80,9 @@ module VagrantAutoDNS
       command_class = @subcommands.get(@sub_command.to_sym) if @sub_command
       return help if !command_class || !@sub_command
       @logger.debug("Invoking command class: #{command_class} #{@sub_args.inspect}")
+
+      # Hack to ensure Vagrantfile gets loaded
+      @env.vagrantfile
 
       # Initialize and execute the command class
       command_class.new(@sub_args, @env).execute

--- a/lib/vagrant-autodns/version.rb
+++ b/lib/vagrant-autodns/version.rb
@@ -8,5 +8,5 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 module VagrantAutoDNS
-    VERSION = '0.0.2'
+    VERSION = '0.0.3'
 end


### PR DESCRIPTION
Vagrant is not loading config prior to running autodns commands, causing working_directory to not be set.

```
gems/rexec-1.6.3/lib/rexec/daemon/base.rb:71:in `join': no implicit conversion of nil into String (TypeError)
```
